### PR TITLE
Refactor jsonapi compliant pagination

### DIFF
--- a/spec/deserializer_spec.rb
+++ b/spec/deserializer_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe Railsful::Deserializer do
     )
   end
 
+  let(:params_with_has_many) do
+    ActionController::Parameters.new(
+      data: {
+        attributes: { foo: 'bar' },
+        relationships: { foo: { data: [{ id: 1 }] } }
+      }
+    )
+  end
+
   let(:params_with_included) do
     ActionController::Parameters.new(
       data: {
@@ -69,6 +78,18 @@ RSpec.describe Railsful::Deserializer do
 
       it 'adds the relationship with _id suffix to hash' do
         expect(deserialized).to eq('foo' => 'bar', 'foo_id' => 1)
+      end
+    end
+
+    context 'when has_many relationship is given' do
+      before do
+        allow(controller)
+          .to receive(:params)
+          .and_return(params_with_has_many)
+      end
+
+      it 'adds the relationship with _id suffix to hash' do
+        expect(deserialized).to eq('foo' => 'bar', 'foo_ids' => [1])
       end
     end
 

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Railsful::Serializer do
       end
 
       context 'when pagination params are given' do
-        let(:params) { { page: 1, per_page: 10 } }
+        let(:params) { { page: { number: 1, size: 10 } } }
 
         it 'does nothing' do
           expect(serializer.render(json)).to eq(json)
@@ -29,7 +29,7 @@ RSpec.describe Railsful::Serializer do
       end
 
       context 'when include params are given' do
-        let(:params) { { page: 1, per_page: 10 } }
+        let(:params) { { include: 'address' } }
 
         it 'does nothing' do
           expect(serializer.render(json)).to eq(json)
@@ -50,7 +50,7 @@ RSpec.describe Railsful::Serializer do
       end
 
       context 'when include params are given' do
-        let(:params) { { page: 1, per_page: 10 } }
+        let(:params) { { include: 'address' } }
 
         it 'adds a links key to the options' do
           expect(DummySerializer)
@@ -63,7 +63,7 @@ RSpec.describe Railsful::Serializer do
       end
 
       context 'when pagination include params are given' do
-        let(:params) { { page: 1, per_page: 10 } }
+        let(:params) { { page: { number: 1, size: 10 } } }
 
         before do
           allow(renderable).to receive(:is_a?).and_return(true)


### PR DESCRIPTION
The current master suppors this kind of pagination:

`?page=10&per_page=25`

But the de facto standard ist:

`?page[number]=10&page[size]=25`

Signed-off-by: Henning Vogt <git@henvo.de>