### PR TITLE
Added passthrough for page render calls.

### DIFF
--- a/lib/railsful/serializable.rb
+++ b/lib/railsful/serializable.rb
@@ -3,6 +3,16 @@
 module Railsful
   module Serializable
     def render(options = nil, extra_options = {}, &block)
+
+      # In case we see regular page-render requests like:
+      #
+      #   render :index, layout: true
+      #
+      # we just pass them through without modification to Rails.
+      if options.is_a?(Symbol) || extra_options.key?(:layout)
+        return super(*[options, extra_options], &block)
+      end
+
       super(fast_jsonapi_options(options), extra_options, &block)
     end
 

--- a/spec/serializable_spec.rb
+++ b/spec/serializable_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Railsful::Serializable do
+  let(:base_controller) do
+    Class.new do
+      def render(*args);
+        check_render(*args)
+      end
+
+      def check_render(*); end
+      def request; end
+      def params; end
+    end
+  end
+  let(:controller) do
+    Class.new(base_controller) do
+      prepend Railsful::Serializable
+
+      def index
+        render :index
+      end
+
+      def new
+        render :new, layout: true
+      end
+
+      def create
+        render json: { test: true }
+      end
+    end.new
+  end
+
+  describe '#render' do
+    context 'with layout' do
+      it 'does not call #fast_jsonapi_options' do
+        expect(controller).not_to receive(:fast_jsonapi_options)
+        controller.new
+      end
+
+      it 'passes the render request through to its super class' do
+        expect(controller).to \
+          receive(:check_render).with(:new, { layout: true })
+        controller.new
+      end
+    end
+
+    context 'with page template' do
+      it 'does not call #fast_jsonapi_options' do
+        expect(controller).not_to receive(:fast_jsonapi_options)
+        controller.index
+      end
+
+      it 'passes the render request through to its super class' do
+        expect(controller).to receive(:check_render).with(:index, {})
+        controller.index
+      end
+    end
+
+    context 'with JSON' do
+      it 'calls #fast_jsonapi_options' do
+        expect(controller).to \
+          receive(:fast_jsonapi_options).with(json: { test: true })
+        controller.create
+      end
+    end
+  end
+end


### PR DESCRIPTION
This update ships an improved Serializable#render method which checks
for page render requests and if such a request is present it just passes
the options down to Rails. Otherwise the regular serializer logic
applies and the fast_jsonapi options helper is called.

With this fix in place we allow applications to mix API actions and
regular page view actions. Thats quite handy in combination with other
gems like administrate, instrumentation frameworks, or
monitoring/profiling solutions.

Signed-off-by: Hermann Mayer <hermann.mayer92@gmail.com>