### PR TITLE
Allow a custom serializer to be given in the options

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ If you want to use another serializer you can do this by specifying a
 
 ``` ruby
 render json: User.first, serializer: 'author'
+
+# or
+
+render json: User.first, serializer: AuthorSerializer
 ```
 
 ### Deserialization

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ GET /some_module/users
 }
 ```
 
+If you want to use another serializer you can do this by specifying a
+`serializer` key inside the options:
+
+``` ruby
+render json: User.first, serializer: 'author'
+```
+
 ### Deserialization
 For deserialization of jsonapi compliant request all controllers that
 inherit from `ActionController` can use the `#deserialized_params` method.

--- a/lib/railsful/serializer.rb
+++ b/lib/railsful/serializer.rb
@@ -39,7 +39,7 @@ module Railsful
       return options unless renderable
 
       # Try to fetch the right serializer for given renderable.
-      serializer = serializer_for(renderable)
+      serializer = serializer_for(renderable, options)
 
       # When no serializer is found just pass the original options hash.
       return options unless serializer
@@ -49,12 +49,34 @@ module Railsful
     end
 
     # Find the right serializer for given object.
+    # First we will look if the options hash includes a serializer. If not,
+    # we try to guess the right serializer from the model/class name.
     #
-    # @param [ApplicationRecord, ActiveRecord::Relation]
+    # @param renderable [ApplicationRecord, ActiveRecord::Relation]
+    # @param options [Hash]
     # @return [Class] The serializer class.
     #
     # :reek:UtilityFunction
-    def serializer_for(renderable)
+    def serializer_for(renderable, options = {})
+      serializer_by_options(options) || serializer_by_renderable(renderable)
+    end
+
+    # Check the options hash for a serializer key.
+    #
+    # @return [Class] The serializer class.
+    #
+    # :reek:UtilityFunction
+    def serializer_by_options(options)
+      serializer = options[:serializer]
+      return unless serializer
+
+      "#{serializer.to_s.classify}Serializer".safe_constantize
+    end
+
+    # @return [Class] The serializer class.
+    #
+    # :reek:UtilityFunction
+    def serializer_by_renderable(renderable)
       # Get the class in order to find the right serializer.
       klass = if renderable.is_a?(ActiveRecord::Relation)
                 renderable.model.name

--- a/lib/railsful/serializer.rb
+++ b/lib/railsful/serializer.rb
@@ -70,6 +70,9 @@ module Railsful
       serializer = options[:serializer]
       return unless serializer
 
+      # If the given serializer is a class return it.
+      return serializer if serializer.is_a? Class
+
       "#{serializer.to_s.classify}Serializer".safe_constantize
     end
 

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -162,6 +162,18 @@ RSpec.describe Railsful::Serializer do
 
           serializer.render(options)
         end
+
+        context 'when the class is given' do
+          before do
+            options.merge(serializer: AnotherDummySerializer)
+          end
+
+          it 'uses the class' do
+            expect(AnotherDummySerializer).to receive(:new)
+
+            serializer.render(options)
+          end
+        end
       end
     end
 

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -153,6 +153,16 @@ RSpec.describe Railsful::Serializer do
           end
         end
       end
+
+      context 'when a serializer is given via options' do
+        let(:options) { { json: renderable, serializer: 'another_dummy' } }
+
+        it 'uses the defined serializer' do
+          expect(AnotherDummySerializer).to receive(:new)
+
+          serializer.render(options)
+        end
+      end
     end
 
     context 'when renderable is an ActiveModel::Errors' do

--- a/spec/support/dummy.rb
+++ b/spec/support/dummy.rb
@@ -29,3 +29,8 @@ end
 class DummySerializer
   def initialize(*_args); end
 end
+
+# An other test serializer class
+class AnotherDummySerializer
+  def initialize(*_args); end
+end


### PR DESCRIPTION
This PR implements this:

``` ruby
render User.first, serializer: 'author'
```
